### PR TITLE
Dv 24276 duplicate streaming capability rule

### DIFF
--- a/docs/rules.json
+++ b/docs/rules.json
@@ -405,6 +405,13 @@
             "type": "error",
             "recommendation": "Remove all UI capabilities from the flow. The only UI capabilities allowed are: 'End Flow Success' and 'End Flow Failure', and they must appear only as end nodes.",
             "code": "dv-er-scheduleFlow-005"
+          },
+          "dv-er-scheduleFlow-006": {
+            "description": "Multiple Batch Process Users capabilities in scheduled flow",
+            "message": "Unsupported node configuration in flow",
+            "type": "error",
+            "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+            "code": "dv-er-scheduleFlow-006"
           }
         },
         "reference": "",

--- a/docs/rules.json
+++ b/docs/rules.json
@@ -410,7 +410,7 @@
             "description": "Multiple Batch Process Users capabilities in scheduled flow",
             "message": "Unsupported node configuration in flow",
             "type": "error",
-            "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+            "recommendation": "This flow has multiple \"Batch Process User\" capabilities. Only one is allowed per Scheduled Flow.",
             "code": "dv-er-scheduleFlow-006"
           }
         },

--- a/rules/dv-rule-scheduleFlow-001/ScheduleFlowRule.js
+++ b/rules/dv-rule-scheduleFlow-001/ScheduleFlowRule.js
@@ -39,6 +39,12 @@ class ScheduleFlowRule extends LintRule {
             type: "error",
             recommendation: "Remove all UI capabilities from the flow. The only UI capabilities allowed are: 'End Flow Success' and 'End Flow Failure', and they must appear only as end nodes.",
         });
+        this.addCode("dv-er-scheduleFlow-006", {
+            description: "Multiple Batch Process Users capabilities in scheduled flow",
+            message: "Unsupported node configuration in flow",
+            type: "error",
+            recommendation: 'There are more than one "Batch Process User" capability in this flow. There can only be one "Batch Process User" capability per Scheduled Flow.',
+        });
 
     }
 
@@ -47,6 +53,22 @@ class ScheduleFlowRule extends LintRule {
             const endNodesCapabilities = ["endFlowSuccess", "endFlowFailure"];
             for (const flow of this.allFlows) {
                 const { nodes, edges } = flow?.graphData?.elements
+
+                if (flow.trigger?.type === "SCHEDULE") {
+                    const streamingNodes = nodes?.filter((node) => {
+                        const { data } = node;
+                        return data?.capabilityClass === "streaming"
+                            || (data?.capabilityClass === undefined && data?.capabilityName === "streamingListUsers");
+                    }) || [];
+
+                    streamingNodes.slice(1).forEach((node) => {
+                        this.addError("dv-er-scheduleFlow-006", {
+                            flowId: flow.flowId,
+                            nodeId: node.data.id,
+                        });
+                    });
+                }
+
                 nodes?.forEach((node) => {
                     const { data } = node;
                     const isScheduleOrBatchProcessingFlow = ["SCHEDULE", "BATCH_PROCESSING_SUBFLOW"].includes(flow.trigger?.type);

--- a/rules/dv-rule-scheduleFlow-001/ScheduleFlowRule.js
+++ b/rules/dv-rule-scheduleFlow-001/ScheduleFlowRule.js
@@ -43,7 +43,7 @@ class ScheduleFlowRule extends LintRule {
             description: "Multiple Batch Process Users capabilities in scheduled flow",
             message: "Unsupported node configuration in flow",
             type: "error",
-            recommendation: 'There are more than one "Batch Process User" capability in this flow. There can only be one "Batch Process User" capability per Scheduled Flow.',
+            recommendation: 'This flow has multiple "Batch Process User" capabilities. Only one is allowed per Scheduled Flow.',
         });
 
     }

--- a/rules/dv-rule-scheduleFlow-001/tests/DuplicateBatchProcessUsers.expect.json
+++ b/rules/dv-rule-scheduleFlow-001/tests/DuplicateBatchProcessUsers.expect.json
@@ -1,0 +1,68 @@
+{
+    "name": "PingOne DaVinci Linter",
+    "pass": false,
+    "errorCount": 2,
+    "rulePackResults": [
+        {
+            "pass": false,
+            "errorCount": 2,
+            "lintResults": [
+                {
+                    "flowId": "dup876730b76356af1161bcde9295bd",
+                    "flowName": "DuplicateBatchProcessUsersFlow",
+                    "pass": false,
+                    "errorCount": 2,
+                    "errors": [
+                        {
+                            "code": "dv-er-scheduleFlow-006",
+                            "flowId": "dup876730b76356af1161bcde9295bd",
+                            "message": "Unsupported node configuration in flow",
+                            "nodeId": "streamNode02",
+                            "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                            "type": "error"
+                        },
+                        {
+                            "code": "dv-er-scheduleFlow-006",
+                            "flowId": "dup876730b76356af1161bcde9295bd",
+                            "message": "Unsupported node configuration in flow",
+                            "nodeId": "streamNode03",
+                            "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                            "type": "error"
+                        }
+                    ],
+                    "rulesApplied": [
+                        "dv-rule-scheduleFlow-001"
+                    ],
+                    "ruleResults": [
+                        {
+                            "ruleDescription": "Schedule flow rules",
+                            "ruleId": "dv-rule-scheduleFlow-001",
+                            "pass": false,
+                            "errorCount": 2,
+                            "errors": [
+                                {
+                                    "code": "dv-er-scheduleFlow-006",
+                                    "flowId": "dup876730b76356af1161bcde9295bd",
+                                    "message": "Unsupported node configuration in flow",
+                                    "nodeId": "streamNode02",
+                                    "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                                    "type": "error"
+                                },
+                                {
+                                    "code": "dv-er-scheduleFlow-006",
+                                    "flowId": "dup876730b76356af1161bcde9295bd",
+                                    "message": "Unsupported node configuration in flow",
+                                    "nodeId": "streamNode03",
+                                    "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                                    "type": "error"
+                                }
+                            ]
+                        }
+                    ],
+                    "rulesIgnored": []
+                }
+            ],
+            "rulesIgnored": true
+        }
+    ]
+}

--- a/rules/dv-rule-scheduleFlow-001/tests/DuplicateBatchProcessUsers.expect.json
+++ b/rules/dv-rule-scheduleFlow-001/tests/DuplicateBatchProcessUsers.expect.json
@@ -18,7 +18,7 @@
                             "flowId": "dup876730b76356af1161bcde9295bd",
                             "message": "Unsupported node configuration in flow",
                             "nodeId": "streamNode02",
-                            "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                            "recommendation": "This flow has multiple \"Batch Process User\" capabilities. Only one is allowed per Scheduled Flow.",
                             "type": "error"
                         },
                         {
@@ -26,7 +26,7 @@
                             "flowId": "dup876730b76356af1161bcde9295bd",
                             "message": "Unsupported node configuration in flow",
                             "nodeId": "streamNode03",
-                            "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                            "recommendation": "This flow has multiple \"Batch Process User\" capabilities. Only one is allowed per Scheduled Flow.",
                             "type": "error"
                         }
                     ],
@@ -45,7 +45,7 @@
                                     "flowId": "dup876730b76356af1161bcde9295bd",
                                     "message": "Unsupported node configuration in flow",
                                     "nodeId": "streamNode02",
-                                    "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                                    "recommendation": "This flow has multiple \"Batch Process User\" capabilities. Only one is allowed per Scheduled Flow.",
                                     "type": "error"
                                 },
                                 {
@@ -53,7 +53,7 @@
                                     "flowId": "dup876730b76356af1161bcde9295bd",
                                     "message": "Unsupported node configuration in flow",
                                     "nodeId": "streamNode03",
-                                    "recommendation": "There are more than one \"Batch Process User\" capability in this flow. There can only be one \"Batch Process User\" capability per Scheduled Flow.",
+                                    "recommendation": "This flow has multiple \"Batch Process User\" capabilities. Only one is allowed per Scheduled Flow.",
                                     "type": "error"
                                 }
                             ]

--- a/rules/dv-rule-scheduleFlow-001/tests/DuplicateBatchProcessUsers.json
+++ b/rules/dv-rule-scheduleFlow-001/tests/DuplicateBatchProcessUsers.json
@@ -1,0 +1,260 @@
+{
+    "flows": [
+        {
+            "companyId": "6YWgejhFHGFyhZM57KfdhnYf7fmeMZKM",
+            "connectorIds": [
+                "pingOneSsoConnector",
+                "flowCanvasToolsConnector"
+            ],
+            "createdDate": 1751263460856,
+            "currentVersion": 1,
+            "customerId": "1576bd3c19c0fb0a828342b21d46a57e",
+            "description": "",
+            "flowStatus": "enabled",
+            "name": "DuplicateBatchProcessUsersFlow",
+            "settings": {
+                "logLevel": 3
+            },
+            "trigger": {
+                "type": "SCHEDULE"
+            },
+            "flowId": "dup876730b76356af1161bcde9295bd",
+            "versionId": 1,
+            "graphData": {
+                "elements": {
+                    "nodes": [
+                        {
+                            "data": {
+                                "id": "startNode01",
+                                "nodeType": "START",
+                                "name": "Start Node",
+                                "label": "Start Node",
+                                "status": "configured",
+                                "type": "action"
+                            },
+                            "position": {
+                                "x": 100,
+                                "y": 100
+                            },
+                            "group": "nodes",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": false,
+                            "locked": true,
+                            "grabbable": false,
+                            "pannable": false,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "streamNode01",
+                                "nodeType": "CONNECTION",
+                                "connectionId": "1234567890abcdef1234567890abcdef",
+                                "connectorId": "pingOneSsoConnector",
+                                "name": "PingOne SSO",
+                                "label": "Batch Process Users",
+                                "status": "configured",
+                                "capabilityName": "streamingListUsers",
+                                "capabilityClass": "streaming",
+                                "type": "action",
+                                "properties": {}
+                            },
+                            "position": {
+                                "x": 250,
+                                "y": 100
+                            },
+                            "group": "nodes",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": false,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "streamNode02",
+                                "nodeType": "CONNECTION",
+                                "connectionId": "1234567890abcdef1234567890abcdef",
+                                "connectorId": "pingOneSsoConnector",
+                                "name": "PingOne SSO",
+                                "label": "Batch Process Users",
+                                "status": "configured",
+                                "capabilityName": "streamingListUsers",
+                                "capabilityClass": "streaming",
+                                "type": "action",
+                                "properties": {}
+                            },
+                            "position": {
+                                "x": 400,
+                                "y": 100
+                            },
+                            "group": "nodes",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": false,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "streamNode03",
+                                "nodeType": "CONNECTION",
+                                "connectionId": "1234567890abcdef1234567890abcdef",
+                                "connectorId": "pingOneSsoConnector",
+                                "name": "PingOne SSO",
+                                "label": "Batch Process Users",
+                                "status": "configured",
+                                "capabilityName": "streamingListUsers",
+                                "capabilityClass": "streaming",
+                                "type": "action",
+                                "properties": {}
+                            },
+                            "position": {
+                                "x": 550,
+                                "y": 100
+                            },
+                            "group": "nodes",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": false,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "endNode01",
+                                "nodeType": "CONNECTION",
+                                "connectionId": "f576602770a3d518c08814b59820fd25",
+                                "connectorId": "flowCanvasToolsConnector",
+                                "name": "Flow Canvas Tools",
+                                "label": "Flow Canvas Tools",
+                                "status": "configured",
+                                "capabilityName": "endFlowSuccess",
+                                "type": "action",
+                                "properties": {}
+                            },
+                            "position": {
+                                "x": 700,
+                                "y": 100
+                            },
+                            "group": "nodes",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": false,
+                            "classes": ""
+                        }
+                    ],
+                    "edges": [
+                        {
+                            "data": {
+                                "id": "edge01",
+                                "source": "startNode01",
+                                "target": "streamNode01"
+                            },
+                            "position": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "group": "edges",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": true,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "edge02",
+                                "source": "streamNode01",
+                                "target": "streamNode02"
+                            },
+                            "position": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "group": "edges",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": true,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "edge03",
+                                "source": "streamNode02",
+                                "target": "streamNode03"
+                            },
+                            "position": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "group": "edges",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": true,
+                            "classes": ""
+                        },
+                        {
+                            "data": {
+                                "id": "edge04",
+                                "source": "streamNode03",
+                                "target": "endNode01"
+                            },
+                            "position": {
+                                "x": 0,
+                                "y": 0
+                            },
+                            "group": "edges",
+                            "removed": false,
+                            "selected": false,
+                            "selectable": true,
+                            "locked": false,
+                            "grabbable": true,
+                            "pannable": true,
+                            "classes": ""
+                        }
+                    ]
+                },
+                "data": {},
+                "zoomingEnabled": true,
+                "userZoomingEnabled": true,
+                "zoom": 1,
+                "minZoom": 1e-50,
+                "maxZoom": 1e+50,
+                "panningEnabled": true,
+                "userPanningEnabled": true,
+                "pan": {
+                    "x": 0,
+                    "y": 0
+                },
+                "boxSelectionEnabled": true,
+                "renderer": {
+                    "name": "null"
+                }
+            },
+            "savedDate": 1751263460776,
+            "variables": [],
+            "connections": [],
+            "parentFlowId": "dup876730b76356af1161bcde9295bd"
+        }
+    ],
+    "companyId": "6YWgejhFHGFyhZM57KfdhnYf7fmeMZKM",
+    "customerId": "1576bd3c19c0fb0a828342b21d46a57e"
+}


### PR DESCRIPTION
Scheduled flows with more than one "Batch Process Users" (streaming) capability node on the canvas now emit one dv-er-scheduleFlow-006 error per duplicate node beyond the first. Detection uses node.data.capabilityClass === "streaming", falling back to capabilityName === "streamingListUsers" when capabilityClass is absent. Adds DuplicateBatchProcessUsers.json/.expect.json fixture pair covering three streaming nodes -> two errors.

DV-24276